### PR TITLE
feat(snap): add content interface for device configuration

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -28,7 +28,11 @@ apps:
       - network-bind
       - gpio
       - i2c
-
+plugs:
+  device-config:
+    interface: content 
+    content: device-config
+    target: $SNAP_DATA/config/edgex-device-grove/res
 parts:
   version:
     plugin: nil


### PR DESCRIPTION
The `device-config` content interface allows another snap to seed this device
snap with initial configuration and device profiles. To use, create a new
snap with the following in snapcraft.yaml:

```
slots:
  device-config:
    interface: content
    read: $SNAP_DATA/device-profiles
```

where device-profiles is the name of a directory with the new configuration
for the device snap. You can then connect the plug in the device snap to
the slot in your snap, which will replace the configuration in the device snap.
Do this with:

```
sudo snap connect edgex-device-grove:device-config your-snap:device-config
```

Signed-off-by: Siggi Skulason <siggi.skulason@canonical.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-grove-c/blob/master/.github/CONTRIBUTING.md

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [ ] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [ ] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
